### PR TITLE
(WIP) Add feature for polarity using SentiWordnet

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ revscoring >= 1.3.5, < 1.3.999
 mysqltsv >= 0.0.7, < 0.0.999
 yamlconf >= 0.2.2, < 0.2.999
 json2tsv >= 0.1.2
-sentiment_classifier >= 0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ revscoring >= 1.3.5, < 1.3.999
 mysqltsv >= 0.0.7, < 0.0.999
 yamlconf >= 0.2.2, < 0.2.999
 json2tsv >= 0.1.2
+sentiment_classifier >= 0.7


### PR DESCRIPTION
Adds a library sentiment_classifier that makes use of SentiWordnet and
WSD to detect the polarity of each word in a document and returns an
aggregate positive and negative score per document. Add these polarity
scores as features to enwiki.py

See - https://phabricator.wikimedia.org/T167305