### PR TITLE
Add NLTK Wordnet requirement to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ draft (new article creation) quality prediction models.
 Optionally requires the following based on usage:
 
 * NLTK SentiWordnet - ``python -m nltk.downloader sentiwordnet``
+* NLTK Wordnet - ``python -m nltk.downloader wordnet``
 
 ## Author
 * Aaron Halfaker -- https://github.com/halfak


### PR DESCRIPTION
Testing the draft quality model resulted in NLTK complaining it couldn't
find the Wordnet corpus (SentiWordnet was already installed). Installing
the Wordnet corpus solved the problem. Thus, adding said requirement to
the readme so others can know how to install it.