### PR TITLE
Release Automation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: python
+dist: trusty
+python:
+  - "3.5"
+addons:
+  apt:
+    packages:
+    - enchant
+
+# command to install dependencies
+install:
+  - pip install -r requirements.txt
+  - python setup.py install
+  - pip install twine
+  - pip install flake8
+
+script:
+  - flake8 . --ignore=E722
+
+after_success:
+  - coverage report
+  - codecov
+
+deploy:
+  provider: script
+  script: bash scripts/deploy.sh
+  on:
+    branch: master

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,3 @@
+python setup.py sdist bdist_wheel && twine upload dist/* --skip-existing --username $PYPI_USER --password $PYPI_PASS
+
+


### PR DESCRIPTION
This PR adds the ability to deploy releases to PyPI via TravisCI.

This is done using a script (`deploy.sh`) which will build the binary and wheels, and upload via twine whenever the version gets incremented.

PyPI Credentials will be stored as private environment variables on the TravisCI repo.

Task: https://phabricator.wikimedia.org/T229850