### PR TITLE
Fix missing version from Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,18 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Added
-- Added enwiki feature lists
-- Added `cache2score` script
 - Add polarity score features to enwiki feature list d306559
 - Add `words_to_watch` to enwiki feature list 458cdfa
 - Added requirement for revscoring v2.5.1
+- Added json2tsv in requirements.txt
 - Release Criteria.
+
+### Changed
+- Included NLTK Wordnet and SentiWordnet requirements to README
+
+## [0.0.1] - 2017-01-31
+First release on PyPI
+### Added
+- Added `cache2score` script
+- Added enwiki feature lists
+- Added cache2feature_tsv.py


### PR DESCRIPTION
This PR adds a missing version (`0.0.1`) to the CHANGELOG.
https://pypi.org/project/draftquality/#history