### PR TITLE
Add sphinx docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,6 @@ nosetests.xml
 coverage.xml
 
 # Sphinx documentation
-doc/_build/
-doc/.buildfile
+docs/_build/
+docs/.buildfile
 *.toctree

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,1 @@
+.. mdinclude:: ../CHANGELOG.md

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,73 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# http://www.sphinx-doc.org/en/master/config
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+# sys.path.insert(0, os.path.abspath('.'))
+dir_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+print(dir_path)
+sys.path.insert(0, dir_path)
+import draftquality  # noqa
+
+# -- Project information -----------------------------------------------------
+
+project = 'Draft Quality'
+copyright = '2019, Scoring Platform Team'
+author = 'Scoring Platform Team'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.todo',
+    'sphinx.ext.coverage',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.ifconfig',
+    'sphinx.ext.viewcode',
+    'm2r'
+]
+
+# The master toctree document.
+master_doc = 'index'
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+html_theme_options = {
+    'github_user': 'wikimedia',
+    'github_repo': 'draftquality',
+    'github_button': True,
+}
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,23 @@
+.. Draft Quality documentation master file, created by
+   sphinx-quickstart on Fri Aug 16 17:16:48 2019.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Draft Quality
+=========================================
+.. automodule:: draftquality
+
+  .. toctree::
+   :maxdepth: 2
+   :caption: Contents
+
+   changelog
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/reference/draftquality.feature_lists.rst
+++ b/docs/reference/draftquality.feature_lists.rst
@@ -1,0 +1,22 @@
+draftquality.feature\_lists package
+===================================
+
+Submodules
+----------
+
+draftquality.feature\_lists.enwiki module
+-----------------------------------------
+
+.. automodule:: draftquality.feature_lists.enwiki
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: draftquality.feature_lists
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/draftquality.rst
+++ b/docs/reference/draftquality.rst
@@ -1,0 +1,39 @@
+.. _api_reference:
+draftquality package
+====================
+
+Subpackages
+-----------
+
+.. toctree::
+
+   draftquality.feature_lists
+   draftquality.utilities
+
+Submodules
+----------
+
+draftquality.about module
+-------------------------
+
+.. automodule:: draftquality.about
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+draftquality.draftquality module
+--------------------------------
+
+.. automodule:: draftquality.draftquality
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: draftquality
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/draftquality.utilities.rst
+++ b/docs/reference/draftquality.utilities.rst
@@ -1,0 +1,22 @@
+draftquality.utilities package
+==============================
+
+Submodules
+----------
+
+draftquality.utilities.fetch\_text module
+-----------------------------------------
+
+.. automodule:: draftquality.utilities.fetch_text
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: draftquality.utilities
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/reference/modules.rst
+++ b/docs/reference/modules.rst
@@ -1,0 +1,7 @@
+draftquality
+============
+
+.. toctree::
+   :maxdepth: 4
+
+   draftquality

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+sphinx>=1.3
+sphinx-py3doc-enhanced-theme
+m2r
+-e .

--- a/draftquality/__init__.py
+++ b/draftquality/__init__.py
@@ -1,3 +1,18 @@
+"""
+This package contains a set of utilities and assets for
+building and maintaining draft (new article creation) quality
+prediction models for Wikipedia.
+
+In this package, you'll find the
+:mod:`feature lists <draftquality.feature_lists>` used to train models
+for the supported wiki.  There's a set of
+:mod:`command-line utilities <draftquality.utilities>`
+that are used to perform data pipeline operations specific to training and
+testing a quality model.
+
+See the :ref:`API Reference <api_reference>` for low level details.
+"""
+
 from .about import (__author__, __author_email__, __description__, __name__,
                     __url__, __version__)
 


### PR DESCRIPTION
This PR adds a Sphinx documentation site.

How to build docs site locally: (w/ python 3)

```
cd docs
make html
cd _build/html
python -m http.server
```
The site should be available at http://localhost:8000

https://phabricator.wikimedia.org/T230517