### PR TITLE
Update deploy script to explicitly install twine

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,3 +1,3 @@
-python setup.py sdist bdist_wheel && twine upload dist/* --skip-existing --username $PYPI_USER --password $PYPI_PASS
+pip install twine && python setup.py sdist bdist_wheel && twine upload dist/* --skip-existing --username $PYPI_USER --password $PYPI_PASS
 
 


### PR DESCRIPTION
This PR contains a fix in the deploy script, where we were not explicitly installing twine like we do in the other repos. This was leading to some weird errors on Travis in the master branch.